### PR TITLE
Add support for parsing project .babelrc config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
-const babel = require('babel-core');
 const fs = require('fs');
 const path = require('path');
+const babel = require('babel-core');
+
+const DEFAULTS = [
+  'transform-flow-strip-types',
+  'syntax-jsx'
+];
 
 /**
  * Remove duplicates from array
  * @param  {array} items Input array
  * @return {array} Output array with unique values
  */
-const arrayUnique = (items) =>
-    items.filter((item, pos, self) => self.indexOf(item) === pos);
+const arrayUnique = (arr) => Array.from(new Set(arr));
 
 /**
  * Construct Babel plugins config object.
@@ -18,23 +22,16 @@ const arrayUnique = (items) =>
  * @return {Object}
  */
 const buildBabelrcConfig = () => {
-  const defaultConfig = ['transform-flow-strip-types', 'syntax-jsx'];
-  const babelrcPath = path.normalize(path.join(__dirname, '..', '..', '.babelrc'));
+  const babelrcPath = path.resolve(__dirname, '..', '..', '.babelrc');
+  const babelrc = JSON.parse(fs.readFileSync(babelrcPath, 'utf8'));
 
-  if (! fs.existsSync(babelrcPath)) {
-    return { plugins: defaultConfig };
-  }
+  const plugins = Array.isArray(babelrc.plugins)
+    ? babelrc.plugins.concat(DEFAULTS)
+    : DEFAULTS;
 
-  const babelrc = JSON.parse(fs.readFileSync(babelrcPath));
-
-  if (! Array.isArray(babelrc.plugins)) {
-    return { plugins: defaultConfig };
-  }
-
-  const plugins = arrayUnique(babelrc.plugins.concat(defaultConfig));
-
-  return { plugins };
+  return { plugins: arrayUnique(plugins) };
 };
+
 
 exports.onHandleCode = (event) => {
   const babelOpts = buildBabelrcConfig();

--- a/index.js
+++ b/index.js
@@ -1,10 +1,44 @@
 const babel = require('babel-core');
+const fs = require('fs');
+const path = require('path');
 
-const babelOpts = {
-  plugins: ['transform-flow-strip-types', 'syntax-jsx']
+/**
+ * Remove duplicates from array
+ * @param  {array} items Input array
+ * @return {array} Output array with unique values
+ */
+const arrayUnique = (items) =>
+    items.filter((item, pos, self) => self.indexOf(item) === pos);
+
+/**
+ * Construct Babel plugins config object.
+ * Honours user's global Babel plugins config. and adds
+ * required Flowtype plugin if not already available.
+ *
+ * @return {Object}
+ */
+const buildBabelrcConfig = () => {
+  const defaultConfig = ['transform-flow-strip-types', 'syntax-jsx'];
+  const babelrcPath = path.normalize(path.join(__dirname, '..', '..', '.babelrc'));
+
+  if (! fs.existsSync(babelrcPath)) {
+    return { plugins: defaultConfig };
+  }
+
+  const babelrc = JSON.parse(fs.readFileSync(babelrcPath));
+
+  if (! Array.isArray(babelrc.plugins)) {
+    return { plugins: defaultConfig };
+  }
+
+  const plugins = arrayUnique(babelrc.plugins.concat(defaultConfig));
+
+  return { plugins };
 };
 
 exports.onHandleCode = (event) => {
+  const babelOpts = buildBabelrcConfig();
+
   try {
     const result = babel.transform(event.data.code, babelOpts);
     event.data.code = result.code;

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
   "dependencies": {
     "babel-core": "6.9.1",
     "babel-plugin-syntax-jsx": "6.8.0",
-    "babel-plugin-transform-flow-strip-types": "6.8.0",
-    "fs": "0.0.1-security",
-    "path": "^0.12.7"
+    "babel-plugin-transform-flow-strip-types": "6.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "babel-core": "6.9.1",
     "babel-plugin-syntax-jsx": "6.8.0",
-    "babel-plugin-transform-flow-strip-types": "6.8.0"
+    "babel-plugin-transform-flow-strip-types": "6.8.0",
+    "fs": "0.0.1-security",
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
Any plugins defined in the project's .babelrc file is parsed and added
to the min plugins required to support flowtype parsing. All duplicate
plugins will be removed before running babel transform.

If no .babelrc file exists in the project then only the default min plugins
are used.