### PR TITLE
Updated Babel-core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">=4.4.4"
   },
   "dependencies": {
-    "babel-core": "6.9.1",
+    "babel-core": "6.25.0",
     "babel-plugin-syntax-jsx": "6.8.0",
     "babel-plugin-transform-flow-strip-types": "6.8.0"
   }


### PR DESCRIPTION
One of dependent module of babel-core (old version 6.9.1) has been deprecated.