### PR TITLE
Archive project: deprecation notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # esdoc-flow-plugin
 
+> ## ⚠️ Archived &amp; deprecated
+>
+> This project is no longer maintained and the npm package is deprecated.
+>
+> ESDoc itself has been unmaintained since 2018, and the ESDoc team already
+> ships an official Flow plugin. If you still need to strip Flow annotations
+> when generating ESDoc documentation, please use that instead:
+>
+> - **[`esdoc-flow-type-plugin`](https://www.npmjs.com/package/esdoc-flow-type-plugin)**
+>   ([source](https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-flow-type-plugin))
+>
+> For new projects, consider TypeScript with [TypeDoc](https://typedoc.org/),
+> which is the actively maintained, modern equivalent.
+>
+> The instructions below are kept for historical reference only.
+
+---
+
 This plugin will remove all Flow annotations and types to produce the documentation.
 
 ## Install and usage


### PR DESCRIPTION
## Summary

Archives this project with an honest status notice in the README, based on an evaluation of the ecosystem it depends on.

### Why archive
- **Flow is still alive** (Meta maintains it, releases as recent as 2026) — but it's a shrinking niche as the ecosystem moved to TypeScript.
- **ESDoc — the host this plugin plugs into — is dead.** Original `esdoc` last published v1.1.0 in **2018**; `esdoc2` (2018) and the most active fork `@enterthenamehere/esdoc` (2023) are also stale.
- **This plugin is redundant.** The ESDoc org already ships an official `esdoc-flow-type-plugin`.
- This package has had exactly **one release (v1.0.0, 2016)** and was never updated.

### What this PR does
- Adds an "Archived & deprecated" notice to the top of `README.md`, directing users to the official [`esdoc-flow-type-plugin`](https://www.npmjs.com/package/esdoc-flow-type-plugin) and to TypeScript/TypeDoc for new projects.
- Keeps the original usage instructions below the notice for historical reference.

The npm package will be marked deprecated separately by the maintainer.

### Notes
- Live npm download stats could not be fetched from the sandbox (network policy blocks `api.npmjs.org`); check npmjs.com directly if a hard number is wanted.
- During evaluation I confirmed the plugin silently fails to strip Flow types when no Babel config is present (the error is caught and logged, leaving code untouched). Not fixed here since the project is being archived.

https://claude.ai/code/session_01AFVi63Bb4F758U2z7mKsYg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFVi63Bb4F758U2z7mKsYg)_